### PR TITLE
 Uses external_id field instead of imo field

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,13 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 ### Added
 
 * [GlobalFishingWatch/GFW-Tasks#1063](https://github.com/GlobalFishingWatch/GFW-Tasks/issues/1063)
+  Normalizes the partitioned table fields.
+
+### Added
+
+## 0.0.2 - (2019-06-18)
+
+* [GlobalFishingWatch/GFW-Tasks#1063](https://github.com/GlobalFishingWatch/GFW-Tasks/issues/1063)
   Process NAF messages and generate a Partitioned Table with them
 
 ### Added

--- a/assets/naf-process-chile.sql.j2
+++ b/assets/naf-process-chile.sql.j2
@@ -1,10 +1,10 @@
 SELECT
   PARSE_TIMESTAMP("%Y%m%d%k%M%S", CONCAT(DA,TI)) timestamp,
 -- inculdes callsign field as NULL because its needed for clustering
-  NULL AS callsign,
+  CAST(NULL AS STRING) AS callsign,
   NA AS shipname,
 -- inculdes registry_number field as NULL because its needed for clustering
-  NULL AS registry_number,
+  CAST(NULL AS STRING) AS registry_number,
   IR AS internal_id,
   XR AS external_id,
   CAST(LT AS FLOAT64) lat,

--- a/assets/naf-process-chile.sql.j2
+++ b/assets/naf-process-chile.sql.j2
@@ -1,5 +1,7 @@
 SELECT
   PARSE_TIMESTAMP("%Y%m%d%k%M%S", CONCAT(DA,TI)) timestamp,
+-- inculdes callsign field as NULL because its needed for clustering
+  NULL AS callsign,
   NA AS shipname,
   IR AS internal_id,
   XR AS external_id,

--- a/assets/naf-process-chile.sql.j2
+++ b/assets/naf-process-chile.sql.j2
@@ -3,6 +3,8 @@ SELECT
 -- inculdes callsign field as NULL because its needed for clustering
   NULL AS callsign,
   NA AS shipname,
+-- inculdes registry_number field as NULL because its needed for clustering
+  NULL AS registry_number,
   IR AS internal_id,
   XR AS external_id,
   CAST(LT AS FLOAT64) lat,

--- a/assets/naf-process-panama.sql.j2
+++ b/assets/naf-process-panama.sql.j2
@@ -4,7 +4,7 @@ SELECT
   NA AS shipname,
   RN AS registry_number,
   IR AS internal_id,
-  IF(XR=RC OR XR="N",NULL,XR) AS imo,
+  XR AS external_id,
   CAST(LT AS FLOAT64) lat,
   CAST(LG AS FLOAT64) lon,
   CAST(SP AS FLOAT64) speed,

--- a/assets/naf-process-schema.json
+++ b/assets/naf-process-schema.json
@@ -37,12 +37,6 @@
   },
   {
     "mode": "NULLABLE",
-    "type": "STRING",
-    "name": "imo",
-    "description": "The IMO (International Maritime Organization) assigned."
-  },
-  {
-    "mode": "NULLABLE",
     "type": "FLOAT",
     "name": "lat",
     "description": "The latitude of the vessel."

--- a/pipe_naf_reader/__init__.py
+++ b/pipe_naf_reader/__init__.py
@@ -2,7 +2,7 @@
 Micro pipeline that parses the NAF messages from countries that handles vessel information with NAF format
 """
 
-__version__ = '0.0.2'
+__version__ = '0.0.3'
 __author__ = 'Matias Piano'
 __email__ = 'matias@globalfishingwatch.org'
 __source__ = 'https://github.com/GlobalFishingWatch/pipe-naf-reader'

--- a/scripts/generate_partitioned_table_daily.sh
+++ b/scripts/generate_partitioned_table_daily.sh
@@ -50,7 +50,8 @@ echo "${SQL}" | bq query \
     --nouse_legacy_sql \
     --destination_schema ${ASSETS}/naf-process-schema.json \
     --destination_table ${BQ_OUTPUT} \
-    --time_partitioning_field timestamp
+    --time_partitioning_field timestamp \
+    --clustering_fields shipname,callsign,registry_number
 
 if [ "$?" -ne 0 ]; then
   echo "  Unable to create table ${BQ_OUTPUT}"


### PR DESCRIPTION
Regarding the changes mentioned in this comment on previous PR.
https://github.com/GlobalFishingWatch/pipe-naf-reader/pull/2#pullrequestreview-251374046

> @smpiano let's change this line
> ` IF(XR=RC OR XR="N",NULL,XR) AS imo,`
> with
> `XR AS external_id,`
> 
> it will be more clear if more nations join and we want to reuse this.

> @smpiano remove the IMO field, only leave the `external_id` one.

> @smpiano add the `callsign	shipname	registry_number` as clustering fields. I think the sintaxt is
> `--clustering_fields shipname,registry_number,callsign`, but look it up just to be sure. Clustering makes queries cheape when quering by those fields.


Related with> https://github.com/GlobalFishingWatch/GFW-Tasks/issues/1063
