### PR TITLE
Adds support for empty NAF fields

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,13 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+## v3.0.1 - 2022-03-27
+
+### Added
+
+* [Data Pipeline/PIPELINE-851](https://globalfishingwatch.atlassian.net/browse/PIPELINE-851): Adds
+  support for fields that come empty, `field1///field2/value2` meaning `value1=None`.
+
 ## v3.0.0 - 2021-05-27
 
 ### Changed

--- a/pipe_naf_reader/__init__.py
+++ b/pipe_naf_reader/__init__.py
@@ -2,7 +2,7 @@
 Micro pipeline that parses the NAF messages from countries that handles vessel information with NAF format
 """
 
-__version__ = '3.0.0'
+__version__ = '3.0.1'
 __author__ = 'Matias Piano'
 __email__ = 'matias@globalfishingwatch.org'
 __source__ = 'https://github.com/GlobalFishingWatch/pipe-naf-reader'

--- a/pipe_naf_reader/naf_parser.py
+++ b/pipe_naf_reader/naf_parser.py
@@ -116,7 +116,11 @@ class NAFParser():
         for line in input_stream:
             stripped_line = line.strip()
             try:
-                splitted = stripped_line.split('//')
+                if len(stripped_line.split('///'))>1:
+                    logging.warn(f"There are empty fields in line {stripped_line}")
+                    splitted = stripped_line.rsplit('//')
+                else:
+                    splitted = stripped_line.split('//')
                 header, row = self.parse(splitted)
                 if csv_writer is None:
                     csv_writer = csv.DictWriter(output_stream, fieldnames=(expectedHeader if (expectedHeader!=[]) else header), delimiter=',', quotechar='"', quoting=csv.QUOTE_MINIMAL)


### PR DESCRIPTION
- The case that applies is  `field1///field2/value2` with no `value1`.

Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-851