### PR TITLE
Include PNG schemas and queries

### DIFF
--- a/assets/naf-default-schema.json
+++ b/assets/naf-default-schema.json
@@ -1,0 +1,140 @@
+[
+  {
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "name": "AC",
+    "description": "Activity. Letter code of the activity of the vessel."
+  },
+  {
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "name": "AD",
+    "description": "The name of the sender (ex. PAN for Panama, FR for France)."
+  },
+  {
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "name": "AE",
+    "description": "Area of Entry. Division Entering into."
+  },
+  {
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "name": "AF",
+    "description": "Assigned inspectors. Identification of the inspector; 3-Alpha country code and number, in pairs as needed."
+  },
+  {
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "name": "AU",
+    "description": "Authentication. Code to authenticate the report or message used for flag state domestic purposes."
+  },
+  {
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "name": "BA",
+    "description": "Bait. Type of bait."
+  },
+  {
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "name": "BD",
+    "description": "Block Date. UTC time for the data in the block."
+  },
+  {
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "name": "BE",
+    "description": "Beam length (Gear). Beam length in meters."
+  },
+  {
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "name": "BT",
+    "description": "Block Time. UTC time for the data in the block."
+  },
+  {
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "name": "BD",
+    "description": "Block Date. UTC time for the data in the block."
+  },
+  {
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "name": "FR",
+    "description": ""
+  },
+  {
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "name": "TM",
+    "description": "The transmission method used."
+  },
+  {
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "name": "NA",
+    "description": "The vessel name."
+  },
+  {
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "name": "IR",
+    "description": "The internal registry."
+  },
+  {
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "name": "RC",
+    "description": "The callsign of the vessel."
+  },
+  {
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "name": "XR",
+    "description": "The IMO number (the letter of the radio sometimes is repeated for local boats, because these do not have IMO number)."
+  },
+  {
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "name": "DA",
+    "description": "The date of the message (YYMMDD)."
+  },
+  {
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "name": "TI",
+    "description": "The time of the message (hh:mm)."
+  },
+  {
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "name": "LT",
+    "description": "The latitude where the vessel is placed."
+  },
+  {
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "name": "LG",
+    "description": "The longitude where the vessel is placed."
+  },
+  {
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "name": "SP",
+    "description": "The speed of the vessel."
+  },
+  {
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "name": "CO",
+    "description": "The course of the vessel."
+  },
+  {
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "name": "FS",
+    "description": "The flag of the vessel."
+  }
+]

--- a/assets/naf-process-png.sql.j2
+++ b/assets/naf-process-png.sql.j2
@@ -1,0 +1,16 @@
+SELECT
+  PARSE_TIMESTAMP("%Y%m%d%k%M%S", CONCAT(DA,TI)) timestamp,
+-- inculdes callsign field as NULL because its needed for clustering
+  RC AS callsign,
+  NA AS shipname,
+-- inculdes registry_number field as NULL because its needed for clustering
+  CAST(NULL AS STRING) AS registry_number,
+  IR AS internal_id,
+  XR AS external_id,
+  CAST(LT AS FLOAT64) lat,
+  CAST(LG AS FLOAT64) lon,
+  CAST(SP AS FLOAT64) speed,
+  CAST(CO AS FLOAT64) course,
+  FS AS flag
+FROM
+  `{{ source }}`

--- a/assets/naf-process-png.sql.j2
+++ b/assets/naf-process-png.sql.j2
@@ -1,5 +1,5 @@
 SELECT
-  PARSE_TIMESTAMP("%Y%m%d%k%M%S", CONCAT(DA,TI)) timestamp,
+  PARSE_TIMESTAMP("%Y%m%d%k%M", CONCAT(DA,TI)) timestamp,
 -- inculdes callsign field as NULL because its needed for clustering
   RC AS callsign,
   NA AS shipname,

--- a/assets/png-schema.json
+++ b/assets/png-schema.json
@@ -1,0 +1,86 @@
+[
+  {
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "name": "AD",
+    "description": "The name of the sender (ex. PAN for Panama, FR for France)."
+  },
+  {
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "name": "FR",
+    "description": ""
+  },
+  {
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "name": "TM",
+    "description": "The transmission method used."
+  },
+  {
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "name": "NA",
+    "description": "The vessel name."
+  },
+  {
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "name": "IR",
+    "description": "The internal registry."
+  },
+  {
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "name": "RC",
+    "description": "The callsign of the vessel."
+  },
+  {
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "name": "XR",
+    "description": "The IMO number (the letter of the radio sometimes is repeated for local boats, because these do not have IMO number)."
+  },
+  {
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "name": "DA",
+    "description": "The date of the message (YYMMDD)."
+  },
+  {
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "name": "TI",
+    "description": "The time of the message (hh:mm)."
+  },
+  {
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "name": "LT",
+    "description": "The latitude where the vessel is placed."
+  },
+  {
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "name": "LG",
+    "description": "The longitude where the vessel is placed."
+  },
+  {
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "name": "SP",
+    "description": "The speed of the vessel."
+  },
+  {
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "name": "CO",
+    "description": "The course of the vessel."
+  },
+  {
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "name": "FS",
+    "description": "The flag of the vessel."
+  }
+]


### PR DESCRIPTION
- Setups the `NAF` Parser process for the **Papua New Guinea** (`PNG`) data.
- Adds the `NAF` default schema that applies to all the countries.
- Concatenates the date and time fields (`DA`, `TI`) with format `YYYYMMDDHHMM`.

Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-1128