### PR TITLE
Converts the BQ_OUTPUT in BQ CLI output format with colon

### DIFF
--- a/scripts/generate_partitioned_table_daily.sh
+++ b/scripts/generate_partitioned_table_daily.sh
@@ -36,8 +36,14 @@ done
 
 YYYYMMDD=$(yyyymmdd ${DS})
 BQ_INPUT_PATH=${BQ_INPUT}_${YYYYMMDD}
-# if double-dot is not present replace only the first dot with double-dot
-BQ_OUTPUT_DOUBLEDOT=$(if [[ ${BQ_OUTPUT} != *":"*  ]]; then echo ${BQ_OUTPUT/./:}; else echo ${BQ_OUTPUT}; fi)
+BQ_PATTERN="^[a-zA-Z0-9_\-]+[\.:][a-zA-Z0-9_\-]+\.[a-zA-Z0-9_\-]+$"
+if [[ "${BQ_OUTPUT}" =~ ${BQ_PATTERN} ]]; then
+  # if double-dot is not present replace only the first dot with double-dot
+  BQ_OUTPUT_DOUBLEDOT=$(if [[ ${BQ_OUTPUT} != *":"*  ]]; then echo ${BQ_OUTPUT/./:}; else echo ${BQ_OUTPUT}; fi)
+else
+  echo "Error passing the BQ_OUTPUT it should match the following pattern (${BQ_PATTERN})."
+  exit 1
+fi
 COUNTRY_NAME=$(echo ${NAME} | cut -d- -f1)
 ################################################################################
 # Executes query reading the input table

--- a/scripts/generate_partitioned_table_daily.sh
+++ b/scripts/generate_partitioned_table_daily.sh
@@ -38,8 +38,8 @@ YYYYMMDD=$(yyyymmdd ${DS})
 BQ_INPUT_PATH=${BQ_INPUT}_${YYYYMMDD}
 BQ_PATTERN="^[a-zA-Z0-9_\-]+[\.:][a-zA-Z0-9_\-]+\.[a-zA-Z0-9_\-]+$"
 if [[ "${BQ_OUTPUT}" =~ ${BQ_PATTERN} ]]; then
-  # if double-dot is not present replace only the first dot with double-dot
-  BQ_OUTPUT_DOUBLEDOT=$(if [[ ${BQ_OUTPUT} != *":"*  ]]; then echo ${BQ_OUTPUT/./:}; else echo ${BQ_OUTPUT}; fi)
+  # if colon punctuation is not present replace only the first dot with colon punctuation.
+  BQ_OUTPUT_COLON=$(if [[ ${BQ_OUTPUT} != *":"*  ]]; then echo ${BQ_OUTPUT/./:}; else echo ${BQ_OUTPUT}; fi)
 else
   echo "Error passing the BQ_OUTPUT it should match the following pattern (${BQ_PATTERN})."
   exit 1
@@ -57,12 +57,12 @@ echo "${SQL}" | bq query \
     --append_table \
     --nouse_legacy_sql \
     --destination_schema ${ASSETS}/naf-process-schema.json \
-    --destination_table ${BQ_OUTPUT_DOUBLEDOT} \
+    --destination_table ${BQ_OUTPUT_COLON} \
     --time_partitioning_field timestamp \
     --clustering_fields shipname,callsign,registry_number
 
 if [ "$?" -ne 0 ]; then
-  echo "  Unable to create table ${BQ_OUTPUT_DOUBLEDOT}"
+  echo "  Unable to create table ${BQ_OUTPUT_COLON}"
   exit 1
 fi
 ################################################################################
@@ -76,10 +76,10 @@ TABLE_DESC=(
   "$@"
 )
 TABLE_DESC=$( IFS=$'\n'; echo "${TABLE_DESC[*]}" )
-echo "Updating table description ${BQ_OUTPUT_DOUBLEDOT}"
-bq update --description "${TABLE_DESC}" ${BQ_OUTPUT_DOUBLEDOT}
+echo "Updating table description ${BQ_OUTPUT_COLON}"
+bq update --description "${TABLE_DESC}" ${BQ_OUTPUT_COLON}
 if [ "$?" -ne 0 ]; then
-  echo "  Unable to update the description table ${BQ_OUTPUT_DOUBLEDOT}"
+  echo "  Unable to update the description table ${BQ_OUTPUT_COLON}"
   exit 1
 fi
-echo "  ${BQ_OUTPUT_DOUBLEDOT} Done."
+echo "  ${BQ_OUTPUT_COLON} Done."

--- a/scripts/generate_partitioned_table_daily.sh
+++ b/scripts/generate_partitioned_table_daily.sh
@@ -36,6 +36,8 @@ done
 
 YYYYMMDD=$(yyyymmdd ${DS})
 BQ_INPUT_PATH=${BQ_INPUT}_${YYYYMMDD}
+# if double-dot is not present replace only the first dot with double-dot
+BQ_OUTPUT_DOUBLEDOT=$(if [[ ${BQ_OUTPUT} != *":"*  ]]; then echo ${BQ_OUTPUT/./:}; else echo ${BQ_OUTPUT}; fi)
 COUNTRY_NAME=$(echo ${NAME} | cut -d- -f1)
 ################################################################################
 # Executes query reading the input table
@@ -49,12 +51,12 @@ echo "${SQL}" | bq query \
     --append_table \
     --nouse_legacy_sql \
     --destination_schema ${ASSETS}/naf-process-schema.json \
-    --destination_table ${BQ_OUTPUT} \
+    --destination_table ${BQ_OUTPUT_DOUBLEDOT} \
     --time_partitioning_field timestamp \
     --clustering_fields shipname,callsign,registry_number
 
 if [ "$?" -ne 0 ]; then
-  echo "  Unable to create table ${BQ_OUTPUT}"
+  echo "  Unable to create table ${BQ_OUTPUT_DOUBLEDOT}"
   exit 1
 fi
 ################################################################################
@@ -68,10 +70,10 @@ TABLE_DESC=(
   "$@"
 )
 TABLE_DESC=$( IFS=$'\n'; echo "${TABLE_DESC[*]}" )
-echo "Updating table description ${BQ_OUTPUT}"
-bq update --description "${TABLE_DESC}" ${BQ_OUTPUT}
+echo "Updating table description ${BQ_OUTPUT_DOUBLEDOT}"
+bq update --description "${TABLE_DESC}" ${BQ_OUTPUT_DOUBLEDOT}
 if [ "$?" -ne 0 ]; then
-  echo "  Unable to update the description table ${BQ_OUTPUT}"
+  echo "  Unable to update the description table ${BQ_OUTPUT_DOUBLEDOT}"
   exit 1
 fi
-echo "  ${BQ_OUTPUT} Done."
+echo "  ${BQ_OUTPUT_DOUBLEDOT} Done."


### PR DESCRIPTION
That it's using the syntax `project:dataset.table` because it requires the bq.